### PR TITLE
Fixed question deletion blocker FIOT-6 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/onlineTests/Question.java
+++ b/src/main/java/org/fenixedu/academic/domain/onlineTests/Question.java
@@ -51,6 +51,10 @@ public class Question extends Question_Base {
         setRootDomainObject(null);
         getStudentTestsQuestionsSet().clear();
         getTestQuestionsSet().clear();
+        QuestionFile qf = getQuestionFile();
+        if (qf != null) {
+            qf.delete();
+        }
         super.deleteDomainObject();
     }
 

--- a/src/main/java/org/fenixedu/academic/domain/onlineTests/QuestionFile.java
+++ b/src/main/java/org/fenixedu/academic/domain/onlineTests/QuestionFile.java
@@ -18,4 +18,10 @@ class QuestionFile extends QuestionFile_Base {
         return false;
     }
 
+    @Override
+    public void delete() {
+        setQuestion(null);
+        super.delete();
+    }
+
 }


### PR DESCRIPTION
When a question had a questionFile, it was impossible to delete it as it
could only be deleted if the questionFile was deleted and it's deletion
method wasn't triggering the removal the questionFile.
